### PR TITLE
Adding force_object_key to be able to specify an artifact to deploy

### DIFF
--- a/lib/capistrano/s3_archive.rb
+++ b/lib/capistrano/s3_archive.rb
@@ -57,7 +57,11 @@ module Capistrano
       end
 
       def latest_object_key
-        list_objects.sort(&fetch(:sort_proc)).first.key
+        if fetch(:force_object_key)
+          fetch(:force_object_key)
+        else
+          list_objects.sort(&fetch(:sort_proc)).first.key
+        end
       end
 
       def parse_s3_uri(uri)


### PR DESCRIPTION
This adds a new optional variable `force_object_key`, to be able to force the deploy of an specific artifact
